### PR TITLE
Trigger CI after dependabot rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,18 @@ on:
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
 
+  # Trigger the workflow after dependabot-build workflow completes
+  workflow_run:
+    workflows: [dependabot-build]
+    types: [completed]
+
 jobs:
 
   # Calls a reusable CI NodeJS workflow to qa & test the current repository.
   #   It will install dependencies and produce a code coverage report on success.
   ci:
+    # Do not run if triggered by another workflow run which failed 
+    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') }}
     name: ci
     uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-node.yml@v1
     with:

--- a/.github/workflows/ecbuild.yml
+++ b/.github/workflows/ecbuild.yml
@@ -13,8 +13,15 @@ on:
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
 
+  # Trigger the workflow after dependabot-build workflow completes
+  workflow_run:
+    workflows: [dependabot-build]
+    types: [completed]
+
 jobs:
   ecbuild:
+    # Do not run if triggered by another workflow run which failed 
+    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') }}
     name: ecbuild
     strategy:
       matrix:

--- a/.github/workflows/eckit.yml
+++ b/.github/workflows/eckit.yml
@@ -13,8 +13,15 @@ on:
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
 
+  # Trigger the workflow after dependabot-build workflow completes
+  workflow_run:
+    workflows: [dependabot-build]
+    types: [completed]
+
 jobs:
   eckit:
+    # Do not run if triggered by another workflow run which failed 
+    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') }}
     name: eckit
     strategy:
       matrix:

--- a/.github/workflows/odc.yml
+++ b/.github/workflows/odc.yml
@@ -13,8 +13,15 @@ on:
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
 
+  # Trigger the workflow after dependabot-build workflow completes
+  workflow_run:
+    workflows: [dependabot-build]
+    types: [completed]
+
 jobs:
   odc:
+    # Do not run if triggered by another workflow run which failed 
+    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') }}
     name: odc
     strategy:
       matrix:

--- a/.github/workflows/pyodc.yml
+++ b/.github/workflows/pyodc.yml
@@ -13,8 +13,15 @@ on:
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
 
+  # Trigger the workflow after dependabot-build workflow completes
+  workflow_run:
+    workflows: [dependabot-build]
+    types: [completed]
+
 jobs:
   pyodc:
+    # Do not run if triggered by another workflow run which failed 
+    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') }}
     name: pyodc
     strategy:
       matrix:


### PR DESCRIPTION
Includes changes to CI workflows to trigger after the dependabot-build workflow successfully completes