### PR TITLE
Use PAT for dependabot rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,11 @@ on:
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
 
-  # Trigger the workflow after dependabot-build workflow completes
-  workflow_run:
-    workflows: [dependabot-build]
-    types: [completed]
-
 jobs:
 
   # Calls a reusable CI NodeJS workflow to qa & test the current repository.
   #   It will install dependencies and produce a code coverage report on success.
   ci:
-    # Do not run if triggered by another workflow run which failed 
-    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') }}
     name: ci
     uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-node.yml@v1
     with:

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -3,18 +3,13 @@ name: dependabot-build
 
 # trigger workflow only on opened PRs or on demand
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
     paths:
       - 'package.json'
       - 'package-lock.json'
 
   workflow_dispatch:
-
-# permissions needed for git push
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   build:
@@ -26,6 +21,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref || github.ref  }}
+          token: ${{ secrets.REBUILD_PUSH_TOKEN }}
 
       - name: Git config
         run: |

--- a/.github/workflows/ecbuild.yml
+++ b/.github/workflows/ecbuild.yml
@@ -13,15 +13,8 @@ on:
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
 
-  # Trigger the workflow after dependabot-build workflow completes
-  workflow_run:
-    workflows: [dependabot-build]
-    types: [completed]
-
 jobs:
   ecbuild:
-    # Do not run if triggered by another workflow run which failed 
-    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') }}
     name: ecbuild
     strategy:
       matrix:

--- a/.github/workflows/eckit.yml
+++ b/.github/workflows/eckit.yml
@@ -13,15 +13,8 @@ on:
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
 
-  # Trigger the workflow after dependabot-build workflow completes
-  workflow_run:
-    workflows: [dependabot-build]
-    types: [completed]
-
 jobs:
   eckit:
-    # Do not run if triggered by another workflow run which failed 
-    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') }}
     name: eckit
     strategy:
       matrix:

--- a/.github/workflows/odc.yml
+++ b/.github/workflows/odc.yml
@@ -13,15 +13,8 @@ on:
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
 
-  # Trigger the workflow after dependabot-build workflow completes
-  workflow_run:
-    workflows: [dependabot-build]
-    types: [completed]
-
 jobs:
   odc:
-    # Do not run if triggered by another workflow run which failed 
-    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') }}
     name: odc
     strategy:
       matrix:

--- a/.github/workflows/pyodc.yml
+++ b/.github/workflows/pyodc.yml
@@ -13,15 +13,8 @@ on:
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~
 
-  # Trigger the workflow after dependabot-build workflow completes
-  workflow_run:
-    workflows: [dependabot-build]
-    types: [completed]
-
 jobs:
   pyodc:
-    # Do not run if triggered by another workflow run which failed 
-    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') }}
     name: pyodc
     strategy:
       matrix:


### PR DESCRIPTION
Use personal access token for dependabot rebuild workflow. This will allow other CI workflows to trigger on push and will be visible in the checks tab.