### PR TITLE
Update action runtime to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -118,5 +118,5 @@ outputs:
   coverage_file:
     description: Absolute path to code coverage file, if collected.
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
Update action runtime to node 16, because node 12 actions are deprecated.