### PR TITLE
Add `libaec` as eccodes dependency

### DIFF
--- a/dependency-tree.yml
+++ b/dependency-tree.yml
@@ -18,4 +18,8 @@ metkit:
 
 eckit: ~
 
-eccodes: ~
+eccodes: 
+  deps:
+    - libaec
+
+libaec: ~


### PR DESCRIPTION
Ensures more accurate cache keys