### PR TITLE
Remove mir dependency on metkit

### DIFF
--- a/dependency-tree.yml
+++ b/dependency-tree.yml
@@ -1,11 +1,12 @@
 pgen:
   deps:
     - mir
+    - metkit
 
 mir:
   deps:
     - atlas
-    - metkit
+    - eccodes
 
 atlas:
   deps:


### PR DESCRIPTION
Mir does not depend on metkit, only pgen does.