### PR TITLE
Switch notify_new_pr trigger to pull_request_target

### DIFF
--- a/.github/workflows/notify_new_pr.yml
+++ b/.github/workflows/notify_new_pr.yml
@@ -1,7 +1,7 @@
 name: Notify new PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - "opened"
 


### PR DESCRIPTION
So action triggers when dependabot opens a PR.