### PR TITLE
Allow dependabot to force-push over rebuild commit

### DIFF
--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-node@v3
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build index.js
         run: npm run build

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -42,5 +42,5 @@ jobs:
       - name: Commit & push index.js
         run: |
           git add dist/index.js
-          git commit -m "Rebuild with updated deps from dependabot"
+          git commit -m "Rebuild with updated deps from dependabot" -m "[dependabot skip]"
           git push origin ${{ github.head_ref || github.ref  }}


### PR DESCRIPTION
The dependabot force-push will re-trigger the build. Prevents manual triggering.